### PR TITLE
build(version): use `0.1.0` version

### DIFF
--- a/proc-macro/Cargo.toml
+++ b/proc-macro/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocket-grants-proc-macro"
-version = "0.5.0-rc.2"
+version = "0.1.0"
 description = "A proc-macro way to validate user permissions for `rocket-grants` crate."
 authors.workspace = true
 repository.workspace = true

--- a/rocket-grants/Cargo.toml
+++ b/rocket-grants/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocket-grants"
-version = "0.5.0-rc.2"
+version = "0.1.0"
 description = "Authorization extension for `rocket` to validate user permissions"
 authors.workspace = true
 repository.workspace = true


### PR DESCRIPTION
Don't stick to rocket version, instead the crate should have its own semver version.
