### PR TITLE
refactor!: rename `type` to `ty`

### DIFF
--- a/examples/enum-role/src/main.rs
+++ b/examples/enum-role/src/main.rs
@@ -7,7 +7,7 @@ use rocket_grants::GrantsFairing;
 mod role;
 
 // `proc-macro` way require specify your type. It can be an import or a full path.
-#[rocket_grants::has_any_role("ADMIN", "role::Role::MANAGER", type = "Role")]
+#[rocket_grants::has_any_role("ADMIN", "role::Role::MANAGER", ty = "Role")]
 // For the `ADMIN` or `MANAGER` - endpoint will give the HTTP status 200, otherwise - 403
 #[rocket::get("/macro_secured")]
 async fn macro_secured() -> Status {

--- a/proc-macro/src/lib.rs
+++ b/proc-macro/src/lib.rs
@@ -17,7 +17,7 @@ const HAS_ANY_ROLE: &str = "has_any_role";
 /// Allow to add a conditional restriction based on handlers parameters.
 /// Add the `secure` attribute followed by the the boolean expression to validate based on parameters
 ///
-/// Also you can use you own types instead of Strings, just add `type` attribute with path to type
+/// Also you can use you own types instead of Strings, just add `ty` attribute with path to type
 /// # Examples
 /// ```
 /// use rocket::serde::json::Json;
@@ -44,7 +44,7 @@ const HAS_ANY_ROLE: &str = "has_any_role";
 /// }
 ///
 /// // User must have MyPermissionEnum::OpGetSecret (you own enum example)
-/// #[rocket_grants::has_permissions("MyPermissionEnum::OpGetSecret", type = "MyPermissionEnum")]
+/// #[rocket_grants::has_permissions("MyPermissionEnum::OpGetSecret", ty = "MyPermissionEnum")]
 /// async fn macro_enum_secured() -> &'static str {
 ///     "some secured info"
 /// }

--- a/rocket-grants/README.md
+++ b/rocket-grants/README.md
@@ -56,11 +56,11 @@ async fn macro_secured() -> &'static str {
 <br/>
 
 
-Here is an example using the `type` and `secure` attributes. But these are independent features.
+Here is an example using the `ty` and `secure` attributes. But these are independent features.
 
 `secure` allows you to include some checks in the macro based on function params.
 
-`type` allows you to use a custom type for the roles and permissions (then the fairing needs to be configured). 
+`ty` allows you to use a custom type for the roles and permissions (then the fairing needs to be configured). 
 Take a look at an [enum-role example](../examples/enum-role/src/main.rs)
 
 ```rust,ignore

--- a/rocket-grants/src/lib.rs
+++ b/rocket-grants/src/lib.rs
@@ -53,7 +53,7 @@ pub use fairing::GrantsFairing;
 /// struct User { id: i32 }
 ///
 /// // You own type is also supported (need to configure fairing for this type as well):
-/// #[rocket_grants::has_roles["Role::Admin", "Role::Manager", type = "Role"]]
+/// #[rocket_grants::has_roles["Role::Admin", "Role::Manager", ty = "Role"]]
 /// #[rocket::get("/enum")]
 /// async fn role_enum_macro_secured() -> &'static str {
 ///    "some secured info"

--- a/rocket-grants/tests/proc_macro/type_feature.rs
+++ b/rocket-grants/tests/proc_macro/type_feature.rs
@@ -8,14 +8,14 @@ use rocket::local::asynchronous::{Client, LocalResponse};
 use rocket_grants::{has_roles, GrantsFairing};
 
 // Using imported custom type (in `use` section)
-#[has_roles("ADMIN", type = "Role")]
+#[has_roles("ADMIN", ty = "Role")]
 #[rocket::get("/imported_enum_secure")]
 async fn imported_path_enum_secure() -> Status {
     Status::Ok
 }
 
 // Using a full path to a custom type (enum)
-#[has_roles("crate::common::Role::ADMIN", type = "crate::common::Role")]
+#[has_roles("crate::common::Role::ADMIN", ty = "crate::common::Role")]
 #[rocket::get("/full_path_enum_secure")]
 async fn full_path_enum_secure() -> Status {
     Status::Ok


### PR DESCRIPTION
#### Description:
This is preliminary change to allow update to `syn2`, because keywords are prohibited as attributes.

`syn2` doesn't allow to use keywords as part of `MetaItem` https://github.com/dtolnay/syn/issues/1458



#### Checklist:


- [X] Tests for the changes have been added (_for bug fixes / features_);
- [X] Docs have been added / updated (_for bug fixes / features_).

Needed for https://github.com/DDtKey/rocket-grants/pull/15
