### PR TITLE
feat!: implement the ability to combine permissions with `all` & `any`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,5 +17,5 @@ repository = "https://github.com/DDtKey/rocket-grants"
 authors = ["DDtKey <ddttkey@gmail.com>"]
 
 [workspace.dependencies]
-rocket-grants-proc-macro = { path = "proc-macro", version = "0.1.0" }
-rocket-grants = { path = "rocket-grants", version = "0.1.0" }
+rocket-grants-proc-macro = { path = "proc-macro", version = "0.1.1" }
+rocket-grants = { path = "rocket-grants", version = "0.1.1" }

--- a/examples/base_example.rs
+++ b/examples/base_example.rs
@@ -8,7 +8,7 @@ const ADMIN_RESPONSE: &str = "Hello Admin!";
 const OTHER_RESPONSE: &str = "Hello!";
 
 // An example of protection via `proc-macro`
-#[rocket_grants::has_permissions("OP_READ_ADMIN_INFO")]
+#[rocket_grants::protect("OP_READ_ADMIN_INFO")]
 #[get("/admin")]
 async fn macro_secured() -> &'static str {
     ADMIN_RESPONSE
@@ -24,7 +24,7 @@ async fn manual_secure(details: AuthDetails) -> &'static str {
 }
 
 // An example of protection via `proc-macro` with secure attribute
-#[rocket_grants::has_permissions("ROLE_ADMIN", secure = "user_id == user.id")]
+#[rocket_grants::protect("ROLE_ADMIN", secure = "user_id == user.id")]
 #[post("/resource/<user_id>", data = "<user>")]
 async fn secure_with_params(user_id: i32, user: Json<User>) -> &'static str {
     ADMIN_RESPONSE

--- a/examples/enum-role/src/main.rs
+++ b/examples/enum-role/src/main.rs
@@ -7,7 +7,7 @@ use rocket_grants::GrantsFairing;
 mod role;
 
 // `proc-macro` way require specify your type. It can be an import or a full path.
-#[rocket_grants::protect("Admin", "role::Role::Manager", ty = "Role")]
+#[rocket_grants::protect("Admin", "role::Role::Manager", ty = Role)]
 // For the `Admin` or `Manager` - endpoint will give the HTTP status 200, otherwise - 403
 #[rocket::get("/macro_secured")]
 async fn macro_secured() -> Status {

--- a/examples/enum-role/src/main.rs
+++ b/examples/enum-role/src/main.rs
@@ -7,7 +7,7 @@ use rocket_grants::GrantsFairing;
 mod role;
 
 // `proc-macro` way require specify your type. It can be an import or a full path.
-#[rocket_grants::has_any_role("Admin", "role::Role::Manager", ty = "Role")]
+#[rocket_grants::protect("Admin", "role::Role::Manager", ty = "Role")]
 // For the `Admin` or `Manager` - endpoint will give the HTTP status 200, otherwise - 403
 #[rocket::get("/macro_secured")]
 async fn macro_secured() -> Status {
@@ -28,9 +28,7 @@ async fn manual_secure(details: AuthDetails<Role>) -> &'static str {
 async fn rocket() -> _ {
     rocket::build()
         .mount("/api", rocket::routes![macro_secured, manual_secure])
-        .attach(GrantsFairing::with_extractor_fn(|req| {
-            Box::pin(extract(req))
-        }))
+        .attach(GrantsFairing::with_extractor_fn(|req| Box::pin(extract(req))))
 }
 
 // You can specify any of your own type (`PartialEq` + `Clone`) for the return type wrapped in a vector: rocket::Result<Vec<YOUR_TYPE_HERE>>

--- a/examples/jwt-auth/src/main.rs
+++ b/examples/jwt-auth/src/main.rs
@@ -9,7 +9,7 @@ use crate::claims::Claims;
 
 mod claims;
 
-#[rocket_grants::has_permissions("OP_GET_SECURED_INFO")]
+#[rocket_grants::protect("OP_GET_SECURED_INFO")]
 #[rocket::get("/api/admin")]
 // For the user with permission `OP_GET_SECURED_INFO` - endpoint will give the HTTP status 200, otherwise - 403
 // You can check via cURL (for generate you own token, use `/token` handler):
@@ -21,7 +21,7 @@ async fn permission_secured() -> Status {
     Status::Ok
 }
 
-#[rocket_grants::has_any_role("ADMIN", "MANAGER")]
+#[rocket_grants::protect("ADMIN", "MANAGER")]
 #[rocket::get("/api/manager")]
 // For the `ADMIN` or `MANAGER` - endpoint will give the HTTP status 200, otherwise - 403
 // You can check via cURL (for generate you own token, use `/token` handler):
@@ -41,9 +41,7 @@ async fn rocket() -> _ {
             "/api",
             rocket::routes![permission_secured, manager_secured, create_token],
         )
-        .attach(GrantsFairing::with_extractor_fn(|req| {
-            Box::pin(extract_from_jwt(req))
-        }))
+        .attach(GrantsFairing::with_extractor_fn(|req| Box::pin(extract_from_jwt(req))))
 }
 
 async fn extract_from_jwt(req: &mut Request<'_>) -> Option<Vec<String>> {

--- a/proc-macro/src/expand.rs
+++ b/proc-macro/src/expand.rs
@@ -1,34 +1,43 @@
 use darling::ast::NestedMeta;
 use proc_macro2::{Ident, Span, TokenStream as TokenStream2};
 use quote::{quote, ToTokens};
-use syn::{ExprLit, ItemFn, ReturnType};
+use std::ops::Deref;
+use syn::{ItemFn, ReturnType};
 
-pub(crate) struct HasPermissions {
-    check_fn: Ident,
+const AUTH_DETAILS: &str = "_auth_details_";
+
+#[derive(Debug)]
+enum Condition {
+    Any(Conditions),
+    All(Conditions),
+    Value(syn::LitStr),
+}
+
+#[derive(Debug)]
+struct Conditions(Vec<Condition>);
+
+#[derive(Debug, darling::FromMeta)]
+pub(crate) struct Args {
+    cond: Condition,
+    secure: Option<syn::Expr>,
+    ty: Option<syn::Expr>,
+}
+
+pub(crate) struct ProtectEndpoint {
+    // check_fn: Ident,
     func: ItemFn,
     args: Args,
 }
 
-impl HasPermissions {
-    pub fn new(check_fn: &str, args: Args, func: ItemFn) -> syn::Result<Self> {
-        let check_fn: Ident = syn::parse_str(check_fn)?;
+impl ProtectEndpoint {
+    pub fn new(_check_fn: &str, args: Args, func: ItemFn) -> syn::Result<Self> {
+        // let check_fn: Ident = syn::parse_str(check_fn)?;
 
-        if args.permissions.is_empty() {
-            return Err(syn::Error::new(
-                Span::call_site(),
-                "The #[has_permissions(..)] macro requires at least one `permission` argument",
-            ));
-        }
-
-        Ok(Self {
-            check_fn,
-            func,
-            args,
-        })
+        Ok(Self { func, args })
     }
 }
 
-impl ToTokens for HasPermissions {
+impl ToTokens for ProtectEndpoint {
     fn to_tokens(&self, output: &mut TokenStream2) {
         let func_vis = &self.func.vis;
         let func_block = &self.func.block;
@@ -39,51 +48,34 @@ impl ToTokens for HasPermissions {
         let fn_generics = &fn_sig.generics;
         let fn_args = &fn_sig.inputs;
         let fn_async = &fn_sig.asyncness.unwrap();
-        let fn_output = match &fn_sig.output {
-            ReturnType::Type(ref _arrow, ref ty) => ty.to_token_stream(),
-            ReturnType::Default => {
-                quote! {()}
-            }
-        };
+        let fn_output =
+            match &fn_sig.output {
+                ReturnType::Type(ref _arrow, ref ty) => ty.to_token_stream(),
+                ReturnType::Default => {
+                    quote! {()}
+                }
+            };
 
-        let check_fn = &self.check_fn;
-
-        let args = if self.args.ty.is_some() {
-            let permissions: Vec<syn::Expr> = self
-                .args
-                .permissions
-                .iter()
-                .map(|perm| perm.parse().unwrap())
-                .collect();
-
-            quote! {
-                #(&#permissions,)*
-            }
-        } else {
-            let permissions = &self.args.permissions;
-
-            quote! {
-                #(#permissions,)*
-            }
-        };
+        let condition = self.args.cond.to_tokens(self.args.ty.is_some());
 
         let ty = self
             .args
             .ty
             .as_ref()
-            .map(|t| t.to_token_stream())
+            .map(syn::Expr::to_token_stream)
             .unwrap_or(quote! {String});
 
         let condition = if let Some(expr) = &self.args.secure {
-            quote!(if _auth_details_.#check_fn(&[#args]) && #expr)
+            quote!(if #condition && #expr)
         } else {
-            quote!(if _auth_details_.#check_fn(&[#args]))
+            quote!(if #condition)
         };
+        let auth_details: Ident = Ident::new(AUTH_DETAILS, Span::call_site());
 
         let stream = quote! {
             #(#fn_attrs)*
             #func_vis #fn_async fn #fn_name #fn_generics(
-                _auth_details_: rocket_grants::permissions::AuthDetails<#ty>,
+                #auth_details: rocket_grants::permissions::AuthDetails<#ty>,
                 #fn_args
             ) -> Result<#fn_output, rocket::http::Status> {
                 use rocket_grants::permissions::{PermissionsCheck, RolesCheck};
@@ -100,55 +92,114 @@ impl ToTokens for HasPermissions {
     }
 }
 
-#[derive(Default)]
-pub(crate) struct Args {
-    permissions: Vec<syn::LitStr>,
-    secure: Option<syn::Expr>,
-    ty: Option<syn::Expr>,
-}
+impl Condition {
+    fn to_tokens(&self, is_typed: bool) -> TokenStream2 {
+        let auth_details: Ident = Ident::new(AUTH_DETAILS, Span::call_site());
 
-impl darling::FromMeta for Args {
-    fn from_list(items: &[NestedMeta]) -> darling::Result<Self> {
-        let mut permissions = Vec::new();
-        let mut secure = None;
-        let mut ty = None;
+        match self {
+            Condition::Any(nested) if nested.iter().all(Condition::is_value) => {
+                let vals = nested.iter().map(|c| match c {
+                    Condition::Value(val) => val,
+                    _ => unreachable!(),
+                });
 
-        for item in items {
-            match item {
-                NestedMeta::Meta(syn::Meta::NameValue(syn::MetaNameValue {
-                    path,
-                    value:
-                        syn::Expr::Lit(ExprLit {
-                            lit: syn::Lit::Str(lit_str),
-                            ..
-                        }),
-                    ..
-                })) => {
-                    if path.is_ident("secure") {
-                        let expr = lit_str.parse().unwrap();
-                        secure = Some(expr);
-                    } else if path.is_ident("ty") {
-                        let expr = lit_str.parse().unwrap();
-                        ty = Some(expr);
-                    } else {
-                        return Err(darling::Error::unknown_field_path(path));
-                    }
+                if is_typed {
+                    let vals: Vec<syn::Expr> =
+                        vals.map(syn::LitStr::parse).map(Result::unwrap).collect();
+
+                    quote! { #auth_details.has_any_permission(&[#(#vals,)*]) }
+                } else {
+                    quote! { #auth_details.has_any_permission(&[#(#vals,)*]) }
                 }
-                NestedMeta::Lit(syn::Lit::Str(lit)) => {
-                    permissions.push(lit.clone());
+            }
+            Condition::All(nested) if nested.iter().all(Condition::is_value) => {
+                let vals = nested.iter().map(|c| match c {
+                    Condition::Value(val) => val,
+                    _ => unreachable!(),
+                });
+
+                if is_typed {
+                    let vals: Vec<syn::Expr> =
+                        vals.map(syn::LitStr::parse).map(Result::unwrap).collect();
+
+                    quote! { #auth_details.has_permissions(&[#(#vals,)*]) }
+                } else {
+                    quote! { #auth_details.has_permissions(&[#(#vals,)*]) }
                 }
-                _ => {
-                    return Err(darling::Error::custom(
-                        "Unknown attribute, available: 'secure', 'ty' & string literal",
-                    ))
+            }
+            Condition::Any(nested) => {
+                let exprs: Vec<_> = nested.iter().map(|c| c.to_tokens(is_typed)).collect();
+
+                quote! { #(#exprs)||* }
+            }
+            Condition::All(nested) => {
+                let exprs: Vec<_> = nested.iter().map(|c| c.to_tokens(is_typed)).collect();
+
+                quote! { #(#exprs)&&* }
+            }
+            Condition::Value(val) => {
+                if is_typed {
+                    let val: syn::Expr = val.parse().unwrap();
+                    quote! { #auth_details.has_permission(&#val) }
+                } else {
+                    quote! { #auth_details.has_permission(#val) }
                 }
             }
         }
+    }
 
-        Ok(Args {
-            permissions,
-            secure,
-            ty,
-        })
+    fn is_value(&self) -> bool {
+        matches!(self, Condition::Value(_))
+    }
+}
+
+impl darling::FromMeta for Condition {
+    fn from_list(items: &[NestedMeta]) -> darling::Result<Self> {
+        match *items {
+            [] => Err(darling::Error::too_few_items(1)),
+            [NestedMeta::Meta(ref meta)] => {
+                match darling::util::path_to_string(meta.path()).as_ref() {
+                    "any" => Ok(Condition::Any(
+                        darling::FromMeta::from_meta(meta).map_err(|e| e.at("any"))?,
+                    )),
+                    "all" => Ok(Condition::All(
+                        darling::FromMeta::from_meta(meta).map_err(|e| e.at("all"))?,
+                    )),
+                    other => Err(
+                        darling::Error::unknown_field_with_alts(other, &["any", "all"])
+                            .with_span(meta),
+                    ),
+                }
+            }
+            [NestedMeta::Lit(ref lit)] => Ok(Condition::Value(darling::FromMeta::from_value(lit)?)),
+            _ => Err(darling::Error::too_many_items(1)),
+        }
+    }
+
+    fn from_string(value: &str) -> darling::Result<Self> {
+        Ok(Condition::Value(darling::FromMeta::from_string(value)?))
+    }
+}
+
+impl darling::FromMeta for Conditions {
+    fn from_list(items: &[NestedMeta]) -> darling::Result<Self> {
+        let mut expressions = Vec::new();
+        for item in items {
+            let expr = match item {
+                nested @ NestedMeta::Meta(_) => Condition::from_list(&[nested.clone()])?,
+                NestedMeta::Lit(lit) => Condition::Value(darling::FromMeta::from_value(lit)?),
+            };
+            expressions.push(expr);
+        }
+
+        Ok(Conditions(expressions))
+    }
+}
+
+impl Deref for Conditions {
+    type Target = Vec<Condition>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
     }
 }

--- a/proc-macro/src/lib.rs
+++ b/proc-macro/src/lib.rs
@@ -40,7 +40,7 @@ mod expand;
 /// }
 ///
 /// // User must have MyPermissionEnum::OpGetSecret (you own enum example)
-/// #[rocket_grants::protect("MyPermissionEnum::OpGetSecret", ty = "MyPermissionEnum")]
+/// #[rocket_grants::protect("MyPermissionEnum::OpGetSecret", ty = MyPermissionEnum)]
 /// async fn macro_enum_secured() -> &'static str {
 ///     "some secured info"
 /// }

--- a/proc-macro/src/lib.rs
+++ b/proc-macro/src/lib.rs
@@ -5,7 +5,7 @@ use proc_macro::TokenStream;
 use quote::ToTokens;
 use syn::{parse_macro_input, ItemFn};
 
-use crate::expand::{Args, HasPermissions};
+use crate::expand::{Args, ProtectEndpoint};
 
 mod expand;
 
@@ -73,7 +73,7 @@ pub fn has_any_permission(args: TokenStream, input: TokenStream) -> TokenStream 
 }
 
 /// Macro to сheck that the user has all the specified roles.
-/// Role - is permission with prefix "ROLE_" or your own custom type.
+/// Role - is string with prefix "ROLE_" or your own custom type.
 ///
 /// # Examples
 /// ```
@@ -89,7 +89,7 @@ pub fn has_roles(args: TokenStream, input: TokenStream) -> TokenStream {
 }
 
 /// Macro to сheck that the user has any the specified roles.
-/// Role - is permission with prefix "ROLE_" or your own custom type.
+/// Role - is string with prefix "ROLE_" or your own custom type.
 ///
 /// # Examples
 /// ```
@@ -120,7 +120,7 @@ fn check_permissions(check_fn_name: &str, args: TokenStream, input: TokenStream)
 
     let func = parse_macro_input!(input as ItemFn);
 
-    match HasPermissions::new(check_fn_name, args, func) {
+    match ProtectEndpoint::new(check_fn_name, args, func) {
         Ok(has_permissions) => has_permissions.into_token_stream().into(),
         Err(err) => err.to_compile_error().into(),
     }

--- a/proc-macro/src/lib.rs
+++ b/proc-macro/src/lib.rs
@@ -9,12 +9,6 @@ use crate::expand::{Args, ProtectEndpoint};
 
 mod expand;
 
-const HAS_AUTHORITIES: &str = "has_permissions";
-const HAS_ANY_AUTHORITY: &str = "has_any_permission";
-
-const HAS_ROLES: &str = "has_roles";
-const HAS_ANY_ROLE: &str = "has_any_role";
-
 /// Macro to сheck that the user has all the specified permissions.
 /// Allow to add a conditional restriction based on handlers parameters.
 /// Add the `secure` attribute followed by the the boolean expression to validate based on parameters
@@ -25,7 +19,7 @@ const HAS_ANY_ROLE: &str = "has_any_role";
 /// use rocket::serde::json::Json;
 ///
 /// // User should be ADMIN with OP_GET_SECRET permission
-/// #[rocket_grants::has_permissions("ROLE_ADMIN", "OP_GET_SECRET")]
+/// #[rocket_grants::protect("ROLE_ADMIN", "OP_GET_SECRET")]
 /// async fn macro_secured() -> &'static str {
 ///     "some secured info"
 /// }
@@ -35,7 +29,7 @@ const HAS_ANY_ROLE: &str = "has_any_role";
 /// #[derive(serde::Deserialize)]
 /// struct User {id: i32}
 ///
-/// #[rocket_grants::has_permissions("ROLE_ADMIN", "OP_GET_SECRET", secure="user_id == user.id")]
+/// #[rocket_grants::protect("ROLE_ADMIN", "OP_GET_SECRET", secure="user_id == user.id")]
 /// async fn macro_secured_params(user_id: i32, user: Json<User>) -> &'static str {
 ///     "some secured info with user_id path equal to user.id"
 ///}
@@ -46,65 +40,18 @@ const HAS_ANY_ROLE: &str = "has_any_role";
 /// }
 ///
 /// // User must have MyPermissionEnum::OpGetSecret (you own enum example)
-/// #[rocket_grants::has_permissions("MyPermissionEnum::OpGetSecret", ty = "MyPermissionEnum")]
+/// #[rocket_grants::protect("MyPermissionEnum::OpGetSecret", ty = "MyPermissionEnum")]
 /// async fn macro_enum_secured() -> &'static str {
 ///     "some secured info"
 /// }
 ///
 ///```
 #[proc_macro_attribute]
-pub fn has_permissions(args: TokenStream, input: TokenStream) -> TokenStream {
-    check_permissions(HAS_AUTHORITIES, args, input)
+pub fn protect(args: TokenStream, input: TokenStream) -> TokenStream {
+    protect_endpoint(args, input)
 }
 
-/// Macro to сheck that the user has any of the specified permissions.
-///
-/// # Examples
-/// ```
-/// // User should be ADMIN or MANAGER
-/// #[rocket_grants::has_any_permission("ROLE_ADMIN", "ROLE_MANAGER")]
-/// async fn macro_secured() -> &'static str {
-///     "some secured info"
-/// }
-/// ```
-#[proc_macro_attribute]
-pub fn has_any_permission(args: TokenStream, input: TokenStream) -> TokenStream {
-    check_permissions(HAS_ANY_AUTHORITY, args, input)
-}
-
-/// Macro to сheck that the user has all the specified roles.
-/// Role - is string with prefix "ROLE_" or your own custom type.
-///
-/// # Examples
-/// ```
-/// // User should be ADMIN and MANAGER
-/// #[rocket_grants::has_roles("ADMIN", "MANAGER")]
-/// async fn macro_secured() -> &'static str {
-///     "some secured info"
-/// }
-/// ```
-#[proc_macro_attribute]
-pub fn has_roles(args: TokenStream, input: TokenStream) -> TokenStream {
-    check_permissions(HAS_ROLES, args, input)
-}
-
-/// Macro to сheck that the user has any the specified roles.
-/// Role - is string with prefix "ROLE_" or your own custom type.
-///
-/// # Examples
-/// ```
-/// // User should be ADMIN or MANAGER
-/// #[rocket_grants::has_any_role("ADMIN", "MANAGER")]
-/// async fn macro_secured() -> &'static str {
-///     "some secured info"
-/// }
-/// ```
-#[proc_macro_attribute]
-pub fn has_any_role(args: TokenStream, input: TokenStream) -> TokenStream {
-    check_permissions(HAS_ANY_ROLE, args, input)
-}
-
-fn check_permissions(check_fn_name: &str, args: TokenStream, input: TokenStream) -> TokenStream {
+fn protect_endpoint(args: TokenStream, input: TokenStream) -> TokenStream {
     let args = match NestedMeta::parse_meta_list(args.into()) {
         Ok(v) => v,
         Err(e) => {
@@ -120,8 +67,8 @@ fn check_permissions(check_fn_name: &str, args: TokenStream, input: TokenStream)
 
     let func = parse_macro_input!(input as ItemFn);
 
-    match ProtectEndpoint::new(check_fn_name, args, func) {
-        Ok(has_permissions) => has_permissions.into_token_stream().into(),
+    match ProtectEndpoint::new(args, func) {
+        Ok(protected) => protected.into_token_stream().into(),
         Err(err) => err.to_compile_error().into(),
     }
 }

--- a/rocket-grants/README.md
+++ b/rocket-grants/README.md
@@ -43,7 +43,7 @@ async fn extract(req: &rocket::Request<'_>) -> Option<Vec<String>>
 
 ### Example of `proc-macro` way protection
 ```rust,no_run
-#[rocket_grants::has_permissions("OP_READ_SECURED_INFO")]
+#[rocket_grants::protect("OP_READ_SECURED_INFO")]
 #[rocket::get("/")]
 async fn macro_secured() -> &'static str {
    "ADMIN_RESPONSE"
@@ -67,7 +67,7 @@ Take a look at an [enum-role example](../examples/enum-role/src/main.rs)
 use enums::Role::{self, ADMIN};
 use dto::User;
 
-#[rocket_grants::has_roles("USER", secure = "user_id == user.id")]
+#[rocket_grants::protect("USER", secure = "user_id == user.id")]
 #[rocket::post("/secure/<user_id>", data = "<user>")]
 async fn role_macro_secured_with_params(user_id: i32, user: Json<User>) -> &'static str {
    "some secured info with parameters"

--- a/rocket-grants/src/fairing.rs
+++ b/rocket-grants/src/fairing.rs
@@ -35,7 +35,7 @@ type Extractor<Type> = Box<
 ///
 /// // `has_permissions` is one of options to validate permissions.
 /// // `proc-macro` crate has additional features, like ABAC security and custom types. See examples and `proc-macro` crate docs.
-/// #[rocket_grants::has_permissions("ROLE_ADMIN")]
+/// #[rocket_grants::protect("ROLE_ADMIN")]
 /// #[rocket::get("/")]
 /// async fn endpoint() -> Status {
 ///     Status::Ok

--- a/rocket-grants/src/lib.rs
+++ b/rocket-grants/src/lib.rs
@@ -34,7 +34,7 @@ pub use fairing::GrantsFairing;
 ///    "some secured info"
 /// }
 ///
-/// // Role - is permission with prefix "ROLE_".
+/// // Role - is string with prefix "ROLE_".
 /// // User should be ADMIN and MANAGER
 /// #[rocket_grants::has_roles["ADMIN", "MANAGER"]]
 /// #[rocket::get("/role")]

--- a/rocket-grants/src/lib.rs
+++ b/rocket-grants/src/lib.rs
@@ -53,7 +53,7 @@ pub use fairing::GrantsFairing;
 /// struct User { id: i32 }
 ///
 /// // You own type is also supported (need to configure fairing for this type as well):
-/// #[rocket_grants::protect(any("Role::Admin", "Role::Manager"), ty = "Role")]
+/// #[rocket_grants::protect(any("Role::Admin", "Role::Manager"), ty = Role)]
 /// #[rocket::get("/enum")]
 /// async fn role_enum_macro_secured() -> &'static str {
 ///    "some secured info"

--- a/rocket-grants/src/lib.rs
+++ b/rocket-grants/src/lib.rs
@@ -28,7 +28,7 @@ pub use fairing::GrantsFairing;
 /// use rocket::serde::json::Json;
 ///
 /// // User should be ADMIN with OP_GET_SECRET permission
-/// #[rocket_grants::has_permissions["ROLE_ADMIN", "OP_GET_SECRET"]]
+/// #[rocket_grants::protect("ROLE_ADMIN", "OP_GET_SECRET")]
 /// #[rocket::get("/")]
 /// async fn macro_secured() -> &'static str {
 ///    "some secured info"
@@ -36,14 +36,14 @@ pub use fairing::GrantsFairing;
 ///
 /// // Role - is string with prefix "ROLE_".
 /// // User should be ADMIN and MANAGER
-/// #[rocket_grants::has_roles["ADMIN", "MANAGER"]]
+/// #[rocket_grants::protect("ADMIN", "MANAGER")]
 /// #[rocket::get("/role")]
 /// async fn role_macro_secured() -> &'static str {
 ///    "some secured info"
 /// }
 ///
 /// // Additional security condition to ensure the protection of the endpoint
-/// #[rocket_grants::has_roles("USER", secure = "user_id == user.id")]
+/// #[rocket_grants::protect("USER", secure = "user_id == user.id")]
 /// #[rocket::post("/secure/<user_id>", data = "<user>")]
 /// async fn role_macro_secured_with_params(user_id: i32, user: Json<User>) -> &'static str {
 ///    "some secured info with parameters"
@@ -53,7 +53,7 @@ pub use fairing::GrantsFairing;
 /// struct User { id: i32 }
 ///
 /// // You own type is also supported (need to configure fairing for this type as well):
-/// #[rocket_grants::has_roles["Role::Admin", "Role::Manager", ty = "Role"]]
+/// #[rocket_grants::protect(any("Role::Admin", "Role::Manager"), ty = "Role")]
 /// #[rocket::get("/enum")]
 /// async fn role_enum_macro_secured() -> &'static str {
 ///    "some secured info"

--- a/rocket-grants/tests/proc_macro/different_fn_types.rs
+++ b/rocket-grants/tests/proc_macro/different_fn_types.rs
@@ -6,13 +6,13 @@ use rocket::serde::json::Json;
 use rocket_grants::{has_roles, GrantsFairing};
 use serde::{Deserialize, Serialize};
 
-#[has_roles(cond("ADMIN"))]
+#[has_roles("ADMIN")]
 #[rocket::get("/http_response")]
 async fn http_response() -> Status {
     Status::Ok
 }
 
-#[has_roles(cond(all(any("ADMIN", "MANAGER"), "USER")))]
+#[has_roles("ADMIN")]
 #[rocket::get("/str")]
 async fn str_response() -> &'static str {
     "Hi!"
@@ -23,19 +23,19 @@ struct User {
     id: i32,
 }
 
-#[has_roles(cond("ADMIN"), secure = "user_id == user.id")]
+#[has_roles("ADMIN", secure = "user_id == user.id")]
 #[rocket::post("/secure/<user_id>", data = "<user>")]
 async fn secure_user_id(user_id: i32, user: Json<User>) -> &'static str {
     "Hi!"
 }
 
-#[has_roles(cond("ADMIN"))]
+#[has_roles("ADMIN")]
 #[rocket::get("/return")]
 async fn return_response() -> &'static str {
     return "Hi!";
 }
 
-#[has_roles(cond("ADMIN"))]
+#[has_roles("ADMIN")]
 #[rocket::get("/result?<name>")]
 async fn result_response(name: Option<String>) -> Result<String, Status> {
     let name = name.as_ref().ok_or(Status::MethodNotAllowed)?;

--- a/rocket-grants/tests/proc_macro/different_fn_types.rs
+++ b/rocket-grants/tests/proc_macro/different_fn_types.rs
@@ -3,16 +3,16 @@ use rocket::http::hyper::header::AUTHORIZATION;
 use rocket::http::{Header, Status};
 use rocket::local::asynchronous::{Client, LocalResponse};
 use rocket::serde::json::Json;
-use rocket_grants::{has_roles, GrantsFairing};
+use rocket_grants::{protect, GrantsFairing};
 use serde::{Deserialize, Serialize};
 
-#[has_roles("ADMIN")]
+#[protect("ROLE_ADMIN")]
 #[rocket::get("/http_response")]
 async fn http_response() -> Status {
     Status::Ok
 }
 
-#[has_roles("ADMIN")]
+#[protect("ROLE_ADMIN")]
 #[rocket::get("/str")]
 async fn str_response() -> &'static str {
     "Hi!"
@@ -23,19 +23,19 @@ struct User {
     id: i32,
 }
 
-#[has_roles("ADMIN", secure = "user_id == user.id")]
+#[protect("ROLE_ADMIN", secure = "user_id == user.id")]
 #[rocket::post("/secure/<user_id>", data = "<user>")]
 async fn secure_user_id(user_id: i32, user: Json<User>) -> &'static str {
     "Hi!"
 }
 
-#[has_roles("ADMIN")]
+#[protect("ROLE_ADMIN")]
 #[rocket::get("/return")]
 async fn return_response() -> &'static str {
     return "Hi!";
 }
 
-#[has_roles("ADMIN")]
+#[protect("ROLE_ADMIN")]
 #[rocket::get("/result?<name>")]
 async fn result_response(name: Option<String>) -> Result<String, Status> {
     let name = name.as_ref().ok_or(Status::MethodNotAllowed)?;
@@ -114,7 +114,9 @@ fn unauthorized_catcher() -> String {
 async fn test_custom_error() {
     let app = rocket::build()
         .mount("/", rocket::routes![str_response])
-        .attach(GrantsFairing::with_extractor_fn(|req| Box::pin(common::extract(req))))
+        .attach(GrantsFairing::with_extractor_fn(|req| {
+            Box::pin(common::extract(req))
+        }))
         .register(
             "/",
             rocket::catchers!(forbidden_catcher, unauthorized_catcher),
@@ -145,7 +147,9 @@ async fn get_client() -> Client {
                 secure_user_id,
             ],
         )
-        .attach(GrantsFairing::with_extractor_fn(|req| Box::pin(common::extract(req))));
+        .attach(GrantsFairing::with_extractor_fn(|req| {
+            Box::pin(common::extract(req))
+        }));
     Client::untracked(app).await.unwrap()
 }
 

--- a/rocket-grants/tests/proc_macro/type_feature.rs
+++ b/rocket-grants/tests/proc_macro/type_feature.rs
@@ -5,24 +5,24 @@ use crate::common::{
 use rocket::http::hyper::header::AUTHORIZATION;
 use rocket::http::{Header, Status};
 use rocket::local::asynchronous::{Client, LocalResponse};
-use rocket_grants::{has_roles, GrantsFairing};
+use rocket_grants::{protect, GrantsFairing};
 
 // Using imported custom type (in `use` section)
-#[has_roles("Admin", ty = "Role")]
+#[protect("Admin", ty = "Role")]
 #[rocket::get("/imported_enum_secure")]
 async fn imported_path_enum_secure() -> Status {
     Status::Ok
 }
 
 // Using a full path to a custom type (enum)
-#[has_roles("crate::common::Role::Admin", ty = "crate::common::Role")]
+#[protect("crate::common::Role::Admin", ty = "crate::common::Role")]
 #[rocket::get("/full_path_enum_secure")]
 async fn full_path_enum_secure() -> Status {
     Status::Ok
 }
 
 // Incorrect endpoint security without Type specification
-#[has_roles("ADMIN")]
+#[protect("ADMIN")]
 #[rocket::get("/incorrect_enum_secure")]
 async fn incorrect_enum_secure() -> Status {
     Status::Ok
@@ -67,7 +67,9 @@ async fn get_client() -> Client {
                 incorrect_enum_secure,
             ],
         )
-        .attach(GrantsFairing::with_extractor_fn(|req| Box::pin(common::enum_extract(req))));
+        .attach(GrantsFairing::with_extractor_fn(|req| {
+            Box::pin(common::enum_extract(req))
+        }));
     Client::untracked(app).await.unwrap()
 }
 async fn get_user_response<'a>(

--- a/rocket-grants/tests/proc_macro/type_feature.rs
+++ b/rocket-grants/tests/proc_macro/type_feature.rs
@@ -67,7 +67,9 @@ async fn get_client() -> Client {
                 incorrect_enum_secure,
             ],
         )
-        .attach(GrantsFairing::with_extractor_fn(|req| Box::pin(common::enum_extract(req))));
+        .attach(GrantsFairing::with_extractor_fn(|req| {
+            Box::pin(common::enum_extract(req))
+        }));
     Client::untracked(app).await.unwrap()
 }
 async fn get_user_response<'a>(

--- a/rocket-grants/tests/proc_macro/type_feature.rs
+++ b/rocket-grants/tests/proc_macro/type_feature.rs
@@ -8,21 +8,21 @@ use rocket::local::asynchronous::{Client, LocalResponse};
 use rocket_grants::{has_roles, GrantsFairing};
 
 // Using imported custom type (in `use` section)
-#[has_roles("Admin", ty = "Role")]
+#[has_roles(cond("Admin"), ty = "Role")]
 #[rocket::get("/imported_enum_secure")]
 async fn imported_path_enum_secure() -> Status {
     Status::Ok
 }
 
 // Using a full path to a custom type (enum)
-#[has_roles("crate::common::Role::Admin", ty = "crate::common::Role")]
+#[has_roles(cond("crate::common::Role::Admin"), ty = "crate::common::Role")]
 #[rocket::get("/full_path_enum_secure")]
 async fn full_path_enum_secure() -> Status {
     Status::Ok
 }
 
 // Incorrect endpoint security without Type specification
-#[has_roles("ADMIN")]
+#[has_roles(cond("ADMIN"))]
 #[rocket::get("/incorrect_enum_secure")]
 async fn incorrect_enum_secure() -> Status {
     Status::Ok
@@ -67,9 +67,7 @@ async fn get_client() -> Client {
                 incorrect_enum_secure,
             ],
         )
-        .attach(GrantsFairing::with_extractor_fn(|req| {
-            Box::pin(common::enum_extract(req))
-        }));
+        .attach(GrantsFairing::with_extractor_fn(|req| Box::pin(common::enum_extract(req))));
     Client::untracked(app).await.unwrap()
 }
 async fn get_user_response<'a>(

--- a/rocket-grants/tests/proc_macro/type_feature.rs
+++ b/rocket-grants/tests/proc_macro/type_feature.rs
@@ -8,14 +8,14 @@ use rocket::local::asynchronous::{Client, LocalResponse};
 use rocket_grants::{protect, GrantsFairing};
 
 // Using imported custom type (in `use` section)
-#[protect("Admin", ty = "Role")]
+#[protect("Admin", ty = Role)]
 #[rocket::get("/imported_enum_secure")]
 async fn imported_path_enum_secure() -> Status {
     Status::Ok
 }
 
 // Using a full path to a custom type (enum)
-#[protect("crate::common::Role::Admin", ty = "crate::common::Role")]
+#[protect("crate::common::Role::Admin", ty = crate::common::Role)]
 #[rocket::get("/full_path_enum_secure")]
 async fn full_path_enum_secure() -> Status {
     Status::Ok
@@ -67,9 +67,7 @@ async fn get_client() -> Client {
                 incorrect_enum_secure,
             ],
         )
-        .attach(GrantsFairing::with_extractor_fn(|req| {
-            Box::pin(common::enum_extract(req))
-        }));
+        .attach(GrantsFairing::with_extractor_fn(|req| Box::pin(common::enum_extract(req))));
     Client::untracked(app).await.unwrap()
 }
 async fn get_user_response<'a>(

--- a/rocket-grants/tests/proc_macro/type_feature.rs
+++ b/rocket-grants/tests/proc_macro/type_feature.rs
@@ -8,21 +8,21 @@ use rocket::local::asynchronous::{Client, LocalResponse};
 use rocket_grants::{has_roles, GrantsFairing};
 
 // Using imported custom type (in `use` section)
-#[has_roles(cond("Admin"), ty = "Role")]
+#[has_roles("Admin", ty = "Role")]
 #[rocket::get("/imported_enum_secure")]
 async fn imported_path_enum_secure() -> Status {
     Status::Ok
 }
 
 // Using a full path to a custom type (enum)
-#[has_roles(cond("crate::common::Role::Admin"), ty = "crate::common::Role")]
+#[has_roles("crate::common::Role::Admin", ty = "crate::common::Role")]
 #[rocket::get("/full_path_enum_secure")]
 async fn full_path_enum_secure() -> Status {
     Status::Ok
 }
 
 // Incorrect endpoint security without Type specification
-#[has_roles(cond("ADMIN"))]
+#[has_roles("ADMIN")]
 #[rocket::get("/incorrect_enum_secure")]
 async fn incorrect_enum_secure() -> Status {
     Status::Ok


### PR DESCRIPTION
#### Description:
Introduces ability to use `any` & `all`

For example:
```rs
#[rocket_grants::protect(all("User", any("Manager", "Admin")), ty = Role]
fn my_endpoint(..) -> Response { .. }
```
Which means the endpoint requires `User` role AND either `Manager` or `Admin`.

The same could be also written as:
```rs
#[rocket_grants::protect("User", any("Manager", "Admin"), ty = Role]
fn my_endpoint(..) -> Response { .. }
```
Upper-level permissions/roles will be considered as `all`


#### Checklist:

- [X] Tests for the changes have been added (_for bug fixes / features_);
- [X] Docs have been added / updated (_for bug fixes / features_).
  -  partially, doc will be improved later

<!-- If this PR fixes or closes an issue, reference it here. -->
Closes #3
