### PR TITLE
perf!: switch to `HashSet` to improve performance

### DIFF
--- a/examples/enum-role/src/role.rs
+++ b/examples/enum-role/src/role.rs
@@ -1,5 +1,5 @@
 // `PartialEq` and `Clone` is required
-#[derive(PartialEq, Clone)]
+#[derive(PartialEq, Eq, Hash)]
 pub enum Role {
     Admin,
     Manager,

--- a/proc-macro/src/lib.rs
+++ b/proc-macro/src/lib.rs
@@ -34,7 +34,7 @@ mod expand;
 ///     "some secured info with user_id path equal to user.id"
 ///}
 ///
-/// #[derive(Clone, PartialEq, Eq)]
+/// #[derive(Hash, PartialEq, Eq)]
 /// enum MyPermissionEnum {
 ///   OpGetSecret
 /// }

--- a/rocket-grants/README.md
+++ b/rocket-grants/README.md
@@ -25,7 +25,7 @@ Provides a complete analogue of the [`actix-web-grants`] and [`poem-grants`].
 The easiest way is to declare a function with the following signature:
 ```rust,ignore
 // You can use custom type instead of String
-async fn extract(req: &rocket::Request<'_>) -> Option<Vec<String>>
+async fn extract(req: &rocket::Request<'_>) -> Option<HashSet<String>>
 ```
 
 2. Add fairing to your application using the extraction function defined in step 1

--- a/rocket-grants/src/lib.rs
+++ b/rocket-grants/src/lib.rs
@@ -58,7 +58,7 @@ pub use fairing::GrantsFairing;
 /// async fn role_enum_macro_secured() -> &'static str {
 ///    "some secured info"
 /// }
-/// #[derive(PartialEq, Clone)] // required bounds
+/// #[derive(Eq, PartialEq, Hash)] // required bounds
 /// enum Role { Admin, Manager }
 ///
 /// ```

--- a/rocket-grants/src/permissions/attache.rs
+++ b/rocket-grants/src/permissions/attache.rs
@@ -1,5 +1,6 @@
 use crate::permissions::{AuthDetails, AuthDetailsWrapper};
 use rocket::Request;
+use std::hash::Hash;
 
 /// Allows you to transfer permissions to [`rocket-grants`] from your custom fairing.
 ///
@@ -20,13 +21,11 @@ use rocket::Request;
 /// [`rocket-grants`]: crate
 /// [`&mut Request`]: rocket::Request
 pub trait AttachPermissions<Type> {
-    fn attach(&mut self, permissions: Option<Vec<Type>>);
+    fn attach(&mut self, permissions: Option<impl IntoIterator<Item = Type>>);
 }
 
-impl<'r, Type: PartialEq + Clone + Send + Sync + 'static> AttachPermissions<Type>
-    for &mut Request<'r>
-{
-    fn attach(&mut self, permissions: Option<Vec<Type>>) {
+impl<'r, Type: Eq + Hash + Send + Sync + 'static> AttachPermissions<Type> for &mut Request<'r> {
+    fn attach(&mut self, permissions: Option<impl IntoIterator<Item = Type>>) {
         let auth_details = permissions
             .map(AuthDetails::new)
             .map(|details| AuthDetailsWrapper(Some(details)))

--- a/rocket-grants/src/permissions/attache.rs
+++ b/rocket-grants/src/permissions/attache.rs
@@ -10,9 +10,10 @@ use std::hash::Hash;
 ///
 /// ```
 /// use rocket_grants::permissions::AttachPermissions;
+/// use std::collections::HashSet;
 ///
 /// // You can use you own type/enum instead of `String`
-/// fn attach(mut req: &mut rocket::Request, permissions: Option<Vec<String>>) {
+/// fn attach(mut req: &mut rocket::Request, permissions: Option<HashSet<String>>) {
 ///     req.attach(permissions);
 /// }
 ///

--- a/rocket-grants/tests/common.rs
+++ b/rocket-grants/tests/common.rs
@@ -1,31 +1,32 @@
 use rocket::http::hyper::header::AUTHORIZATION;
 use rocket::local::asynchronous::LocalResponse;
 use rocket::Request;
+use std::collections::HashSet;
 use std::fmt::{Display, Formatter};
 
 pub const ROLE_ADMIN: &str = "ROLE_ADMIN";
 pub const ROLE_MANAGER: &str = "ROLE_MANAGER";
 
-#[derive(PartialEq, Clone)]
+#[derive(PartialEq, Eq, Hash)]
 pub enum Role {
     Admin,
     Manager,
 }
 
-pub async fn extract(req: &mut Request<'_>) -> Option<Vec<String>> {
+pub async fn extract(req: &mut Request<'_>) -> Option<HashSet<String>> {
     let auth_headers: Vec<&str> = req.headers().get(AUTHORIZATION.as_str()).collect();
 
     auth_headers
         .first()
-        .map(|h| h.split(',').map(str::to_string).collect::<Vec<String>>())
+        .map(|h| h.split(',').map(str::to_string).collect())
 }
 
-pub async fn enum_extract(req: &mut Request<'_>) -> Option<Vec<Role>> {
+pub async fn enum_extract(req: &mut Request<'_>) -> Option<HashSet<Role>> {
     let auth_headers: Vec<&str> = req.headers().get(AUTHORIZATION.as_str()).collect();
 
     auth_headers
         .first()
-        .map(|h| h.split(',').map(|name| name.into()).collect::<Vec<Role>>())
+        .map(|h| h.split(',').map(|name| name.into()).collect())
 }
 
 pub async fn test_body(resp: LocalResponse<'_>, expected_body: &str) {


### PR DESCRIPTION
`Vec` isn't a good choice when we need to check by `contains` condition (because of O(n) complexity)


#### Checklist:
<!-- Don't delete these items! For completed items, change [ ] to [x]. -->

- [X] Tests for the changes have been added (_for bug fixes / features_);
- [X] Docs have been added / updated (_for bug fixes / features_).

