### PR TITLE
refactor!: replace `secure` flag with `expr` and allow combining

### DIFF
--- a/examples/base_example.rs
+++ b/examples/base_example.rs
@@ -24,7 +24,7 @@ async fn manual_secure(details: AuthDetails) -> &'static str {
 }
 
 // An example of protection via `proc-macro` with secure attribute
-#[rocket_grants::protect("ROLE_ADMIN", secure = "user_id == user.id")]
+#[rocket_grants::protect("ROLE_ADMIN", expr = "user_id == user.id")]
 #[post("/resource/<user_id>", data = "<user>")]
 async fn secure_with_params(user_id: i32, user: Json<User>) -> &'static str {
     ADMIN_RESPONSE

--- a/proc-macro/src/expand.rs
+++ b/proc-macro/src/expand.rs
@@ -45,13 +45,12 @@ impl ToTokens for ProtectEndpoint {
         let fn_generics = &fn_sig.generics;
         let fn_args = &fn_sig.inputs;
         let fn_async = &fn_sig.asyncness.unwrap();
-        let fn_output =
-            match &fn_sig.output {
-                ReturnType::Type(ref _arrow, ref ty) => ty.to_token_stream(),
-                ReturnType::Default => {
-                    quote! {()}
-                }
-            };
+        let fn_output = match &fn_sig.output {
+            ReturnType::Type(ref _arrow, ref ty) => ty.to_token_stream(),
+            ReturnType::Default => {
+                quote! {()}
+            }
+        };
 
         let condition = self.args.cond.to_tokens(self.args.ty.is_some());
 
@@ -245,7 +244,9 @@ impl darling::FromMeta for Args {
         }
 
         if conditions.is_empty() {
-            errors.push(darling::Error::custom("At least one condition must be specified"));
+            errors.push(darling::Error::custom(
+                "At least one condition must be specified",
+            ));
         }
 
         errors.finish()?;

--- a/proc-macro/src/expand.rs
+++ b/proc-macro/src/expand.rs
@@ -10,6 +10,7 @@ const AUTH_DETAILS: &str = "_auth_details_";
 enum Condition {
     Any(Conditions),
     All(Conditions),
+    Expr(syn::Expr),
     Value(syn::LitStr),
 }
 
@@ -19,12 +20,10 @@ struct Conditions(Vec<Condition>);
 #[derive(Debug)]
 pub(crate) struct Args {
     cond: Condition,
-    secure: Option<syn::Expr>,
     ty: Option<syn::Expr>,
 }
 
 pub(crate) struct ProtectEndpoint {
-    // check_fn: Ident,
     func: ItemFn,
     args: Args,
 }
@@ -46,12 +45,13 @@ impl ToTokens for ProtectEndpoint {
         let fn_generics = &fn_sig.generics;
         let fn_args = &fn_sig.inputs;
         let fn_async = &fn_sig.asyncness.unwrap();
-        let fn_output = match &fn_sig.output {
-            ReturnType::Type(ref _arrow, ref ty) => ty.to_token_stream(),
-            ReturnType::Default => {
-                quote! {()}
-            }
-        };
+        let fn_output =
+            match &fn_sig.output {
+                ReturnType::Type(ref _arrow, ref ty) => ty.to_token_stream(),
+                ReturnType::Default => {
+                    quote! {()}
+                }
+            };
 
         let condition = self.args.cond.to_tokens(self.args.ty.is_some());
 
@@ -62,11 +62,7 @@ impl ToTokens for ProtectEndpoint {
             .map(syn::Expr::to_token_stream)
             .unwrap_or(quote! {String});
 
-        let condition = if let Some(expr) = &self.args.secure {
-            quote!(if #condition && #expr)
-        } else {
-            quote!(if #condition)
-        };
+        let condition = quote!(if #condition);
         let auth_details: Ident = Ident::new(AUTH_DETAILS, Span::call_site());
 
         let stream = quote! {
@@ -142,6 +138,9 @@ impl Condition {
                     quote! { #auth_details.has_authority(#val) }
                 }
             }
+            Condition::Expr(expr) => {
+                quote! { #expr }
+            }
         }
     }
 
@@ -162,10 +161,14 @@ impl darling::FromMeta for Condition {
                     "all" => Ok(Condition::All(
                         darling::FromMeta::from_meta(meta).map_err(|e| e.at("all"))?,
                     )),
-                    other => Err(
-                        darling::Error::unknown_field_with_alts(other, &["any", "all"])
-                            .with_span(meta),
-                    ),
+                    "expr" => Ok(Condition::Expr(
+                        darling::FromMeta::from_meta(meta).map_err(|e| e.at("expr"))?,
+                    )),
+                    other => Err(darling::Error::unknown_field_with_alts(
+                        other,
+                        &["any", "all", "expr"],
+                    )
+                    .with_span(meta)),
                 }
             }
             [NestedMeta::Lit(ref lit)] => Ok(Condition::Value(darling::FromMeta::from_value(lit)?)),
@@ -196,7 +199,6 @@ impl darling::FromMeta for Conditions {
 impl darling::FromMeta for Args {
     fn from_list(items: &[NestedMeta]) -> darling::Result<Self> {
         let mut conditions = Vec::new();
-        let mut secure = None;
         let mut ty = None;
 
         let mut errors = ::darling::Error::accumulator();
@@ -204,17 +206,18 @@ impl darling::FromMeta for Args {
         for item in items {
             match item {
                 NestedMeta::Meta(Meta::NameValue(syn::MetaNameValue { path, value, .. })) => {
-                    if path.is_ident("secure") {
-                        if secure.is_some() {
-                            errors.push(darling::Error::duplicate_field("secure"));
-                        } else {
-                            secure = errors.handle(darling::FromMeta::from_expr(value));
-                        }
-                    } else if path.is_ident("ty") {
+                    if path.is_ident("ty") {
                         if ty.is_some() {
                             errors.push(darling::Error::duplicate_field("ty"));
                         } else {
                             ty = errors.handle(darling::FromMeta::from_expr(value));
+                        }
+                    } else if path.is_ident("expr") {
+                        let cond = errors
+                            .handle(darling::FromMeta::from_expr(value))
+                            .map(Condition::Expr);
+                        if let Some(cond) = cond {
+                            conditions.push(cond);
                         }
                     } else {
                         errors.push(darling::Error::unknown_field_path(path));
@@ -227,19 +230,22 @@ impl darling::FromMeta for Args {
                         conditions.push(cond);
                     }
                 }
-                NestedMeta::Lit(syn::Lit::Str(lit)) => {
-                    conditions.push(Condition::Value(lit.clone()));
+                NestedMeta::Lit(lit) => {
+                    let cond = errors
+                        .handle(darling::FromMeta::from_value(lit))
+                        .map(Condition::Value);
+                    if let Some(cond) = cond {
+                        conditions.push(cond);
+                    }
                 }
                 _ => errors.push(darling::Error::custom(
-                    "Unknown attribute, available: 'secure', 'ty', `all`, `any` and string literals",
+                    "Unknown attribute, available: 'ty', `all`, `any`, `expr` and string literals",
                 )),
             }
         }
 
         if conditions.is_empty() {
-            errors.push(darling::Error::custom(
-                "At least one condition must be specified",
-            ));
+            errors.push(darling::Error::custom("At least one condition must be specified"));
         }
 
         errors.finish()?;
@@ -250,7 +256,7 @@ impl darling::FromMeta for Args {
             Condition::All(Conditions(conditions))
         };
 
-        Ok(Args { cond, secure, ty })
+        Ok(Args { cond, ty })
     }
 }
 

--- a/proc-macro/src/lib.rs
+++ b/proc-macro/src/lib.rs
@@ -29,7 +29,7 @@ mod expand;
 /// #[derive(serde::Deserialize)]
 /// struct User {id: i32}
 ///
-/// #[rocket_grants::protect("ROLE_ADMIN", "OP_GET_SECRET", secure="user_id == user.id")]
+/// #[rocket_grants::protect("ROLE_ADMIN", "OP_GET_SECRET", expr="user_id == user.id")]
 /// async fn macro_secured_params(user_id: i32, user: Json<User>) -> &'static str {
 ///     "some secured info with user_id path equal to user.id"
 ///}

--- a/proc-macro/src/lib.rs
+++ b/proc-macro/src/lib.rs
@@ -11,7 +11,7 @@ mod expand;
 
 /// Macro to сheck that the user has all the specified permissions.
 /// Allow to add a conditional restriction based on handlers parameters.
-/// Add the `secure` attribute followed by the the boolean expression to validate based on parameters
+/// Add the `expr` attribute followed by the the boolean expression to validate based on parameters
 ///
 /// Also you can use you own types instead of Strings, just add `ty` attribute with path to type
 /// # Examples

--- a/rocket-grants/README.md
+++ b/rocket-grants/README.md
@@ -67,7 +67,7 @@ Take a look at an [enum-role example](../examples/enum-role/src/main.rs)
 use enums::Role::{self, ADMIN};
 use dto::User;
 
-#[rocket_grants::protect("USER", secure = "user_id == user.id")]
+#[rocket_grants::protect("USER", expr = "user_id == user.id")]
 #[rocket::post("/secure/<user_id>", data = "<user>")]
 async fn role_macro_secured_with_params(user_id: i32, user: Json<User>) -> &'static str {
    "some secured info with parameters"

--- a/rocket-grants/README.md
+++ b/rocket-grants/README.md
@@ -56,9 +56,9 @@ async fn macro_secured() -> &'static str {
 <br/>
 
 
-Here is an example using the `ty` and `secure` attributes. But these are independent features.
+Here is an example using the `ty` and `expr` attributes. But these are independent features.
 
-`secure` allows you to include some checks in the macro based on function params.
+`expr` allows you to include some checks in the macro based on function params.
 
 `ty` allows you to use a custom type for the authority (then the fairing needs to be configured). 
 Take a look at an [enum-role example](../examples/enum-role/src/main.rs)

--- a/rocket-grants/src/lib.rs
+++ b/rocket-grants/src/lib.rs
@@ -43,7 +43,7 @@ pub use fairing::GrantsFairing;
 /// }
 ///
 /// // Additional security condition to ensure the protection of the endpoint
-/// #[rocket_grants::protect("USER", secure = "user_id == user.id")]
+/// #[rocket_grants::protect("USER", expr = "user_id == user.id")]
 /// #[rocket::post("/secure/<user_id>", data = "<user>")]
 /// async fn role_macro_secured_with_params(user_id: i32, user: Json<User>) -> &'static str {
 ///    "some secured info with parameters"

--- a/rocket-grants/tests/proc_macro/different_fn_types.rs
+++ b/rocket-grants/tests/proc_macro/different_fn_types.rs
@@ -23,7 +23,7 @@ struct User {
     id: i32,
 }
 
-#[protect("ROLE_ADMIN", secure = "user_id == user.id")]
+#[protect("ROLE_ADMIN", expr = "user_id == user.id")]
 #[rocket::post("/secure/<user_id>", data = "<user>")]
 async fn secure_user_id(user_id: i32, user: Json<User>) -> &'static str {
     "Hi!"
@@ -114,9 +114,7 @@ fn unauthorized_catcher() -> String {
 async fn test_custom_error() {
     let app = rocket::build()
         .mount("/", rocket::routes![str_response])
-        .attach(GrantsFairing::with_extractor_fn(|req| {
-            Box::pin(common::extract(req))
-        }))
+        .attach(GrantsFairing::with_extractor_fn(|req| Box::pin(common::extract(req))))
         .register(
             "/",
             rocket::catchers!(forbidden_catcher, unauthorized_catcher),
@@ -147,9 +145,7 @@ async fn get_client() -> Client {
                 secure_user_id,
             ],
         )
-        .attach(GrantsFairing::with_extractor_fn(|req| {
-            Box::pin(common::extract(req))
-        }));
+        .attach(GrantsFairing::with_extractor_fn(|req| Box::pin(common::extract(req))));
     Client::untracked(app).await.unwrap()
 }
 

--- a/rocket-grants/tests/proc_macro/different_fn_types.rs
+++ b/rocket-grants/tests/proc_macro/different_fn_types.rs
@@ -114,7 +114,9 @@ fn unauthorized_catcher() -> String {
 async fn test_custom_error() {
     let app = rocket::build()
         .mount("/", rocket::routes![str_response])
-        .attach(GrantsFairing::with_extractor_fn(|req| Box::pin(common::extract(req))))
+        .attach(GrantsFairing::with_extractor_fn(|req| {
+            Box::pin(common::extract(req))
+        }))
         .register(
             "/",
             rocket::catchers!(forbidden_catcher, unauthorized_catcher),
@@ -145,7 +147,9 @@ async fn get_client() -> Client {
                 secure_user_id,
             ],
         )
-        .attach(GrantsFairing::with_extractor_fn(|req| Box::pin(common::extract(req))));
+        .attach(GrantsFairing::with_extractor_fn(|req| {
+            Box::pin(common::extract(req))
+        }));
     Client::untracked(app).await.unwrap()
 }
 


### PR DESCRIPTION
#### Description:

This PR removes `secure` flag and instead introduces `expr` which can be combined with authorities, for example:

```rs
#[rocket_grants::protect(any("ROLE_MANAGER", expr = "user.is_super_user()"))]
```
Thus, user should have `ROLE_MANAGER` OR `user.is_super_user() == true`

Additional improvement to syntax requested in #3

#### Checklist:
<!-- Don't delete these items! For completed items, change [ ] to [x]. -->

- [X] Tests for the changes have been added (_for bug fixes / features_);
- [X] Docs have been added / updated (_for bug fixes / features_).

